### PR TITLE
Symfony 3 compatibility

### DIFF
--- a/Resources/config/apiService.yml
+++ b/Resources/config/apiService.yml
@@ -8,31 +8,31 @@ parameters:
 
 services:
     swm.mail_hook.api_service.campainmonitor:
-        class: %swm.mail_hook.api_service.campainmonitor.class%
+        class: "%swm.mail_hook.api_service.campainmonitor.class%"
         tags:
             -  { name: swm.mailhook, alias: campainmonitor }
 
     swm.mail_hook.api_service.mailgun:
-        class: %swm.mail_hook.api_service.mailgun.class%
+        class: "%swm.mail_hook.api_service.mailgun.class%"
         tags:
             -  { name: swm.mailhook, alias: mailgun }
 
     swm.mail_hook.api_service.mailjet:
-        class: %swm.mail_hook.api_service.mailjet.class%
+        class: "%swm.mail_hook.api_service.mailjet.class%"
         tags:
             -  { name: swm.mailhook, alias: mailjet }
 
     swm.mail_hook.api_service.mandrill:
-        class: %swm.mail_hook.api_service.mandrill.class%
+        class: "%swm.mail_hook.api_service.mandrill.class%"
         tags:
             -  { name: swm.mailhook, alias: mandrill }
 
     swm.mail_hook.api_service.sendgrid:
-        class: %swm.mail_hook.api_service.sendgrid.class%
+        class: "%swm.mail_hook.api_service.sendgrid.class%"
         tags:
             -  { name: swm.mailhook, alias: sendgrid }
 
     swm.mail_hook.api_service.sparkpost:
-        class: %swm.mail_hook.api_service.sparkpost.class%
+        class: "%swm.mail_hook.api_service.sparkpost.class%"
         tags:
             -  { name: swm.mailhook, alias: sparkpost }

--- a/Resources/config/service.yml
+++ b/Resources/config/service.yml
@@ -6,15 +6,15 @@ parameters:
 
 services:
     swm.mail_hook.service.mail_hook:
-        class: %swm.mail_hook.service.mail_hook.class%
+        class: "%swm.mail_hook.service.mail_hook.class%"
         scope: request
         arguments:
-            - @request
-            - @swm.mail_hook.provider.api_service
+            - "@request_stack"
+            - "@swm.mail_hook.provider.api_service"
 
     swm.mail_hook.provider.api_service:
-        class: %swm.mail_hook.provider.api_service.class%
+        class: "%swm.mail_hook.provider.api_service.class%"
 
     swm.mail_hook.hydrator.default:
-        class: %swm.mail_hook.hydrator.default.class%
+        class: "%swm.mail_hook.hydrator.default.class%"
 

--- a/Service/MailHookService.php
+++ b/Service/MailHookService.php
@@ -6,6 +6,7 @@ use Swm\Bundle\MailHookBundle\ApiService\ApiServiceInterface;
 use Swm\Bundle\MailHookBundle\Model as ApiServiceModel;
 use Swm\Bundle\MailHookBundle\Provider\ProviderInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 class MailHookService
 {
@@ -20,17 +21,17 @@ class MailHookService
     private $apiServiceModelProvider;
 
     /**
-     * @param  Request           $request
+     * @param  RequestStack      $requestStack
      * @param  ProviderInterface $apiServiceProvider
      */
-    public function __construct(Request $request, ProviderInterface $apiServiceProvider)
+    public function __construct(RequestStack $requestStack, ProviderInterface $apiServiceProvider)
     {
-        $this->request            = $request;
+        $this->request            = $requestStack->getCurrentRequest();
         $this->apiServiceProvider = $apiServiceProvider;
     }
 
     /**
-     * @param  string $apiService
+     * @param  string $serviceName
      * @return array<HookInterface>
      */
     public function getHooksForService($serviceName)

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/framework-bundle": "~2.3|~3.0"
+        "symfony/framework-bundle": "~2.4|~3.0"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"


### PR DESCRIPTION
Usage of `request` service is deprecated since Symfony 2.4 and has been removed in 3.0

I suggest to upgrade minimum version to 2.4 and use service `request_stack` instead