### PR TITLE
Remove deprecated scope & upgrade minimum version to Symfony 2.8

### DIFF
--- a/Resources/config/service.yml
+++ b/Resources/config/service.yml
@@ -7,7 +7,7 @@ parameters:
 services:
     swm.mail_hook.service.mail_hook:
         class: "%swm.mail_hook.service.mail_hook.class%"
-        scope: request
+        shared: false
         arguments:
             - "@request_stack"
             - "@swm.mail_hook.provider.api_service"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.9",
-        "symfony/framework-bundle": "~2.4|~3.0"
+        "symfony/framework-bundle": "~2.8|~3.0"
     },
     "require-dev": {
         "atoum/atoum": "dev-master"


### PR DESCRIPTION
Symfony 2.4 is end of support since Jan 2015

I suggest to upgrade minimum version to 2.8 and fix deprecated scope which does not allow to upgrade to Symfony 4.0

http://symfony.com/blog/new-in-symfony-2-8-deprecating-scopes-and-introducing-shared-services