### PR TITLE
Fix deprecate TreeBuilder::root

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,8 +18,12 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('swm_mailhook');
+        $treeBuilder = new TreeBuilder('swm_mailhook');
+        if (method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            $rootNode = $treeBuilder->root('swm_mailhook');
+        }
 
         $this->addConfig($rootNode);
 


### PR DESCRIPTION
A tree builder without a root node is deprecated since Symfony 4.2 and is not supported anymore in 5.0.